### PR TITLE
fix link to CONTRIBUTING.MD

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You'll need to install [Jekyll](https://jekyllrb.com/), [Ruby](https://www.ruby-
 
 ## Contributing
 
-Thanks for your interest in contributing to the #mozsprint website! There are many ways to contribute. To get started, take a look at [CONTRIBUTING.md](CONTRIBUTING.md).
+Thanks for your interest in contributing to the #mozsprint website! There are many ways to contribute. To get started, take a look at [CONTRIBUTING.md](CONTRIBUTING.MD).
 
 ## Participation Guidelines
 


### PR DESCRIPTION
The file is `CONTRIBUTING.MD`, but the old link was to `CONTRIBUTING.md`, which lead to nowhere as these are case-sensitive. 😸 